### PR TITLE
Bump multiplatform plugin to v1.3.60

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ import org.apache.tools.ant.taskdefs.condition.Os
 plugins {
     id 'maven-publish'
     id 'signing'
-    id 'org.jetbrains.kotlin.multiplatform' version '1.3.40'
+    id 'org.jetbrains.kotlin.multiplatform' version '1.3.60'
     id 'org.jetbrains.dokka' version '0.9.17'
     id 'com.moowork.node' version '1.2.0'
 }


### PR DESCRIPTION
I'm not sure if opentest4k was intentionally on an older version of multiplatform, but the project seems to build fine with 1.3.60. 

assertk is the only dependency blocking [Press](https://github.com/saket/press/pull/22) from updating to 1.3.60. It would be great if we could get this up. :)

```
w: skipping /Users/runner/.gradle/caches/modules-2/files-2.1/com.willowtreeapps.assertk/assertk-iosx64/0.20/1ec8549eaf80103c4566284ecd09d217e806fed3/assertk.klib. The abi versions don't match. Expected '[17]', found '9'
w: The compiler versions don't match either. Expected '[]', found '1.3-release-10826'
e: Could not find "/Users/runner/.gradle/caches/modules-2/files-2.1/com.willowtreeapps.assertk/assertk-iosx64/0.20/1ec8549eaf80103c4566284ecd09d217e806fed3/assertk.klib" in [/Users/runner/runners/2.162.0/work/press/press, /Users/runner/.konan/klib, /Users/runner/.konan/kotlin-native-macos-1.3.60/klib/common, /Users/runner/.konan/kotlin-native-macos-1.3.60/klib/platform/ios_x64].
```