### PR TITLE
Upgrade to Kotlin 1.9 and add experimental WASM target

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,14 +1,13 @@
 import org.jetbrains.dokka.gradle.DokkaTask
-import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTargetWithTests
-import org.jetbrains.kotlin.gradle.targets.js.npm.tasks.KotlinNpmInstallTask
-import java.util.Locale
+import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension
+import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin
 
 plugins {
     `maven-publish`
     signing
     id("io.github.gradle-nexus.publish-plugin") version "1.1.0"
-    kotlin("multiplatform") version "1.8.10"
-    id("org.jetbrains.dokka") version "1.8.10"
+    kotlin("multiplatform") version "1.9.0"
+    id("org.jetbrains.dokka") version "1.8.20"
 }
 
 group = "com.willowtreeapps.opentest4k"
@@ -26,7 +25,10 @@ val nativeTargets = arrayOf(
 
 kotlin {
     jvm()
-    js(IR) {
+    js {
+        nodejs()
+    }
+    wasm {
         nodejs()
     }
 
@@ -60,6 +62,12 @@ kotlin {
             dependsOn(otherMain)
         }
         val jsTest by getting {
+            dependsOn(otherTest)
+        }
+        val wasmMain by getting {
+            dependsOn(otherMain)
+        }
+        val wasmTest by getting {
             dependsOn(otherTest)
         }
         val nativeMain by creating {
@@ -145,4 +153,10 @@ signing {
         findProperty("signing.keyId") != null
     }
     publishing.publications.all { sign(this) }
+}
+
+plugins.withType<NodeJsRootPlugin> {
+    extensions.getByType<NodeJsRootExtension>().apply {
+        nodeVersion = "20.0.0"
+    }
 }

--- a/kotlin-js-store/yarn.lock
+++ b/kotlin-js-store/yarn.lock
@@ -2,11 +2,6 @@
 # yarn lockfile v1
 
 
-"@ungap/promise-all-settled@1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz#aa58042711d6e3275dd37dc597e5d31e8c290a44"
-  integrity sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==
-
 ansi-colors@4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.1.tgz#cbb9ae256bf750af1eab344f229aa27fe94ba348"
@@ -185,7 +180,7 @@ flat@^5.0.2:
   resolved "https://registry.yarnpkg.com/flat/-/flat-5.0.2.tgz#8ca6fe332069ffa9d324c327198c598259ceb241"
   integrity sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==
 
-format-util@1.0.5:
+format-util@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/format-util/-/format-util-1.0.5.tgz#1ffb450c8a03e7bccffe40643180918cc297d271"
   integrity sha512-varLbTj0e0yVyRpqQhuWV+8hlePAgaoFRhNFj50BNjEIrw1/DphHSObtqwskVCPWNgzwPoQrZAbfa/SBiicNeg==
@@ -322,12 +317,11 @@ minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-mocha@10.0.0:
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/mocha/-/mocha-10.0.0.tgz#205447d8993ec755335c4b13deba3d3a13c4def9"
-  integrity sha512-0Wl+elVUD43Y0BqPZBzZt8Tnkw9CMUdNYnUsTfOM1vuhJVZL+kiesFYsqwBkEEuEixaiPe5ZQdqDgX2jddhmoA==
+mocha@10.2.0:
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-10.2.0.tgz#1fd4a7c32ba5ac372e03a17eef435bd00e5c68b8"
+  integrity sha512-IDY7fl/BecMwFHzoqF2sg/SHHANeBoMMXFlS9r0OXKDssYE1M5O43wUY/9BVPeIvfH2zmEbBfseqN9gBQZzXkg==
   dependencies:
-    "@ungap/promise-all-settled" "1.1.2"
     ansi-colors "4.1.1"
     browser-stdout "1.3.1"
     chokidar "3.5.3"
@@ -491,6 +485,11 @@ to-regex-range@^5.0.1:
   integrity sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==
   dependencies:
     is-number "^7.0.0"
+
+typescript@5.0.4:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.4.tgz#b217fd20119bd61a94d4011274e0ab369058da3b"
+  integrity sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==
 
 workerpool@6.2.1:
   version "6.2.1"

--- a/src/wasmMain/kotlin/OpenTest4Wasm.kt
+++ b/src/wasmMain/kotlin/OpenTest4Wasm.kt
@@ -1,0 +1,3 @@
+package com.willowtreeapps.opentest4k
+
+internal actual fun Throwable.className() = this::class.simpleName!!

--- a/src/wasmTest/kotlin/AssertionNames.kt
+++ b/src/wasmTest/kotlin/AssertionNames.kt
@@ -1,0 +1,5 @@
+package com.willowtreeapps.opentest4k
+
+actual val AssertionErrorName = "AssertionError"
+
+actual val AssertionFailedErrorName = "AssertionFailedError"


### PR DESCRIPTION
This is a prerequisite for adding WASM support to AssertK